### PR TITLE
修复无法多次录制的bug

### DIFF
--- a/recorderlib/src/main/java/com/zlw/main/recorderlib/recorder/RecordHelper.java
+++ b/recorderlib/src/main/java/com/zlw/main/recorderlib/recorder/RecordHelper.java
@@ -222,8 +222,10 @@ public class RecordHelper {
             Logger.d(TAG, "record buffer size = %s", bufferSize);
             audioRecord = new AudioRecord(MediaRecorder.AudioSource.MIC, currentConfig.getSampleRate(),
                     currentConfig.getChannelConfig(), currentConfig.getEncodingConfig(), bufferSize);
-            if (currentConfig.getFormat() == RecordConfig.RecordFormat.MP3 && mp3EncodeThread == null) {
-                initMp3EncoderThread(bufferSize);
+            if (currentConfig.getFormat() == RecordConfig.RecordFormat.MP3) {
+                if (mp3EncodeThread == null) {
+                    initMp3EncoderThread(bufferSize);
+                }
             }
         }
 
@@ -311,6 +313,7 @@ public class RecordHelper {
                         @Override
                         public void onFinish() {
                             notifyFinish();
+                            mp3EncodeThread = null;
                         }
                     });
                 } else {


### PR DESCRIPTION
无法录制原因为 mp3encoder 实例 写入 output stream报错导致，
以下原因导致：
1、mp3encoder没有随着录制结束而释放销毁。
2、再次录制时录制文件名没有传入mp3encoder并开启输出流
解决方式
录制结束时在RecordHelper.java中将mp3encoder设置为null以便下次录制开始时重新生成mp3encoder对象